### PR TITLE
Updates for Go 1.17

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,7 @@ name: Test
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         go-version: [1.16.x, 1.17.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,34 +4,34 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.16.x]
+        go-version: [1.16.x, 1.17.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
-    - name: Install Go
-      uses: actions/setup-go@v1
-      with:
-        go-version: ${{ matrix.go-version }}
-    - name: Install staticcheck
-      run: go install honnef.co/go/tools/cmd/staticcheck@latest
-      shell: bash
-    - name: Install golint
-      run: go install golang.org/x/lint/golint@latest
-      shell: bash
-    - name: Update PATH
-      run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
-      shell: bash
-    - name: Checkout code
-      uses: actions/checkout@v1
-    - name: Fmt
-      if: matrix.platform != 'windows-latest' # :(
-      run: "diff <(gofmt -d .) <(printf '')"
-      shell: bash
-    - name: Vet
-      run: go vet ./...
-    - name: Staticcheck
-      run: staticcheck ./...
-    - name: Lint
-      run: golint ./...
-    - name: Test
-      run: go test -race ./...
+      - name: Install Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Install staticcheck
+        run: go install honnef.co/go/tools/cmd/staticcheck@latest
+        shell: bash
+      - name: Install golint
+        run: go install golang.org/x/lint/golint@latest
+        shell: bash
+      - name: Update PATH
+        run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+        shell: bash
+      - name: Checkout code
+        uses: actions/checkout@v1
+      - name: Fmt
+        if: matrix.platform != 'windows-latest' # :(
+        run: "diff <(gofmt -d .) <(printf '')"
+        shell: bash
+      - name: Vet
+        run: go vet ./...
+      - name: Staticcheck
+        run: staticcheck ./...
+      - name: Lint
+        run: golint ./...
+      - name: Test
+        run: go test -race ./...

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/go-kit/log
 
-go 1.16
+go 1.17
 
 require (
-	github.com/go-logfmt/logfmt v0.5.0
-	github.com/go-stack/stack v1.8.0
+	github.com/go-logfmt/logfmt v0.5.1
+	github.com/go-stack/stack v1.8.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/go-logfmt/logfmt v0.5.0 h1:TrB8swr/68K7m9CcGut2g3UOihhbcbiMAYiuTXdEih4=
-github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
-github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
-github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-logfmt/logfmt v0.5.1 h1:otpy5pqBCBZ1ng9RQ0dPu4PN7ba75Y/aA+UpowDyNVA=
+github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
+github.com/go-stack/stack v1.8.1 h1:ntEHSVwIt7PNXNpgPmVfMrNhLtgjlmnZha2kOpuRiDw=
+github.com/go-stack/stack v1.8.1/go.mod h1:dcoOX6HbPZSZptuspn9bctJ+N/CnF5gGygcUP3XYfe4=

--- a/syslog/example_test.go
+++ b/syslog/example_test.go
@@ -1,6 +1,5 @@
-// +build !windows
-// +build !plan9
-// +build !nacl
+//go:build !windows && !plan9 && !nacl
+// +build !windows,!plan9,!nacl
 
 package syslog_test
 

--- a/syslog/syslog.go
+++ b/syslog/syslog.go
@@ -1,6 +1,5 @@
-// +build !windows
-// +build !plan9
-// +build !nacl
+//go:build !windows && !plan9 && !nacl
+// +build !windows,!plan9,!nacl
 
 package syslog
 

--- a/syslog/syslog_test.go
+++ b/syslog/syslog_test.go
@@ -1,6 +1,5 @@
-// +build !windows
-// +build !plan9
-// +build !nacl
+//go:build !windows && !plan9 && !nacl
+// +build !windows,!plan9,!nacl
 
 package syslog
 

--- a/term/colorwriter_others.go
+++ b/term/colorwriter_others.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package term

--- a/term/terminal_linux.go
+++ b/term/terminal_linux.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !appengine
 // +build !appengine
 
 package term

--- a/term/terminal_notwindows.go
+++ b/term/terminal_notwindows.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build (linux && !appengine) || darwin || freebsd || openbsd
 // +build linux,!appengine darwin freebsd openbsd
 
 package term

--- a/term/terminal_stub.go
+++ b/term/terminal_stub.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build appengine || js
 // +build appengine js
 
 package term

--- a/term/terminal_windows.go
+++ b/term/terminal_windows.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build windows
 // +build windows
 
 package term


### PR DESCRIPTION
I want to update this package and tag a patch release before updating `go-kit/kit` in https://github.com/go-kit/kit/pull/1105. I've already updated both of this package's dependencies along the same lines. Just working my way up the tree to minimize the number of new releases and maximize the benefit of the Go 1.17 module pruning feature for consumers.