### PR TITLE
Update CI and add badges to README

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,29 +1,23 @@
-on: push
+on:
+  push:
+  pull_request:
+    types: [synchronize]
 name: Test
 jobs:
   test:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.16.x, 1.17.x]
+        go-version: [1.17.x, 1.18.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
       - name: Install Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go-version }}
-      - name: Install staticcheck
-        run: go install honnef.co/go/tools/cmd/staticcheck@latest
-        shell: bash
-      - name: Install golint
-        run: go install golang.org/x/lint/golint@latest
-        shell: bash
-      - name: Update PATH
-        run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
-        shell: bash
-      - name: Checkout code
-        uses: actions/checkout@v1
       - name: Fmt
         if: matrix.platform != 'windows-latest' # :(
         run: "diff <(gofmt -d .) <(printf '')"
@@ -31,8 +25,25 @@ jobs:
       - name: Vet
         run: go vet ./...
       - name: Staticcheck
-        run: staticcheck ./...
-      - name: Lint
-        run: golint ./...
+        uses: dominikh/staticcheck-action@v1
+        with:
+          install-go: false
+          cache-key: ${{ matrix.go-version }}
       - name: Test
         run: go test -race ./...
+      - name: Test coverage
+        run: go test -coverprofile="cover.out" ./... # quotes needed for powershell
+      - name: Send coverage
+        uses: shogo82148/actions-goveralls@v1
+        with:
+          path-to-profile: cover.out
+          flag-name: go${{ matrix.go-version }}-${{ matrix.os }}
+          parallel: true
+  # notifies that all test jobs are finished.
+  finish:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: shogo82148/actions-goveralls@v1
+        with:
+          parallel-finished: true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # package log
 
+[![Go Reference](https://pkg.go.dev/badge/github.com/go-kit/log.svg)](https://pkg.go.dev/github.com/go-kit/log)
+[![Go Report Card](https://goreportcard.com/badge/go-kit/log)](https://goreportcard.com/report/go-kit/log)
+[![Github Actions](https://github.com/go-kit/log/actions/workflows/test.yml/badge.svg)](https://github.com/go-kit/log/actions/workflows/test.yml)
+[![Coverage Status](https://coveralls.io/repos/github/go-kit/log/badge.svg?branch=master)](https://coveralls.io/github/go-kit/log?branch=main)
+
 `package log` provides a minimal interface for structured logging in services.
 It may be wrapped to encode conventions, enforce type-safety, provide leveled
 logging, and so on. It can be used for both typical application log events,

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/go-kit/log.svg)](https://pkg.go.dev/github.com/go-kit/log)
 [![Go Report Card](https://goreportcard.com/badge/go-kit/log)](https://goreportcard.com/report/go-kit/log)
-[![Github Actions](https://github.com/go-kit/log/actions/workflows/test.yml/badge.svg)](https://github.com/go-kit/log/actions/workflows/test.yml)
+[![GitHub Actions](https://github.com/go-kit/log/actions/workflows/test.yml/badge.svg)](https://github.com/go-kit/log/actions/workflows/test.yml)
 [![Coverage Status](https://coveralls.io/repos/github/go-kit/log/badge.svg?branch=master)](https://coveralls.io/github/go-kit/log?branch=main)
 
 `package log` provides a minimal interface for structured logging in services.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/go-kit/log.svg)](https://pkg.go.dev/github.com/go-kit/log)
 [![Go Report Card](https://goreportcard.com/badge/go-kit/log)](https://goreportcard.com/report/go-kit/log)
 [![GitHub Actions](https://github.com/go-kit/log/actions/workflows/test.yml/badge.svg)](https://github.com/go-kit/log/actions/workflows/test.yml)
-[![Coverage Status](https://coveralls.io/repos/github/go-kit/log/badge.svg?branch=master)](https://coveralls.io/github/go-kit/log?branch=main)
+[![Coverage Status](https://coveralls.io/repos/github/go-kit/log/badge.svg?branch=main)](https://coveralls.io/github/go-kit/log?branch=main)
 
 `package log` provides a minimal interface for structured logging in services.
 It may be wrapped to encode conventions, enforce type-safety, provide leveled

--- a/staticcheck.conf
+++ b/staticcheck.conf
@@ -1,0 +1,1 @@
+checks = ["all"]

--- a/syslog/syslog.go
+++ b/syslog/syslog.go
@@ -1,6 +1,7 @@
 //go:build !windows && !plan9 && !nacl
 // +build !windows,!plan9,!nacl
 
+// Package syslog provides a Logger that writes to syslog.
 package syslog
 
 import (


### PR DESCRIPTION
CI updates:

- Update Go versions (1.17.x and 1.18.x)
- Update actions versions
- Use actions for staticcheck
- Drop golint (deprecated)
- Report test coverage