### PR TITLE
Allow to configure allowed levels by string value

### DIFF
--- a/level/doc.go
+++ b/level/doc.go
@@ -7,11 +7,11 @@
 //    logger = level.NewFilter(logger, level.AllowInfo()) // <--
 //    logger = log.With(logger, "ts", log.DefaultTimestampUTC)
 //
-// It's also possible to configure log level from a string (for instance from
-// a flag, environment variable or configuration file).
+// It's also possible to configure log level from a string. For instance from
+// a flag, environment variable or configuration file.
 //
-//    fs := flag.NewFlagSet("example")
-//    lvl := fs.String("log-level", "", `"debug", "info", "warn" or "error"`)
+//    fs := flag.NewFlagSet("myprogram")
+//    lvl := fs.String("log", "info", "debug, info, warn, error")
 //
 //    var logger log.Logger
 //    logger = log.NewLogfmtLogger(os.Stderr)

--- a/level/doc.go
+++ b/level/doc.go
@@ -7,6 +7,17 @@
 //    logger = level.NewFilter(logger, level.AllowInfo()) // <--
 //    logger = log.With(logger, "ts", log.DefaultTimestampUTC)
 //
+// It's also possible to configure log level from a string (for instance from
+// a flag, environment variable or configuration file).
+//
+//    fs := flag.NewFlagSet("example")
+//    lvl := fs.String("log-level", "", `"debug", "info", "warn" or "error"`)
+//
+//    var logger log.Logger
+//    logger = log.NewLogfmtLogger(os.Stderr)
+//    logger = level.NewFilter(logger, level.Allow(level.ParseDefault(*lvl, level.InfoValue()))) // <--
+//    logger = log.With(logger, "ts", log.DefaultTimestampUTC)
+//
 // Then, at the callsites, use one of the level.Debug, Info, Warn, or Error
 // helper methods to emit leveled log events.
 //

--- a/level/example_test.go
+++ b/level/example_test.go
@@ -35,8 +35,8 @@ func Example_filtered() {
 	level.Debug(logger).Log("next item", 17) // filtered
 
 	// Output:
-	// level=error caller=example_test.go:32 err="bad data"
-	// level=info caller=example_test.go:33 event="data saved"
+	// level=error caller=example_test.go:33 err="bad data"
+	// level=info caller=example_test.go:34 event="data saved"
 }
 
 func Example_parsed() {

--- a/level/example_test.go
+++ b/level/example_test.go
@@ -2,6 +2,7 @@ package level_test
 
 import (
 	"errors"
+	"flag"
 	"os"
 
 	"github.com/go-kit/log"
@@ -36,4 +37,24 @@ func Example_filtered() {
 	// Output:
 	// level=error caller=example_test.go:32 err="bad data"
 	// level=info caller=example_test.go:33 event="data saved"
+}
+
+func Example_parsed() {
+	fs := flag.NewFlagSet("example", flag.ExitOnError)
+	lvl := fs.String("log-level", "", `"debug", "info", "warn" or "error"`)
+	fs.Parse([]string{"-log-level", "info"})
+
+	// Set up logger with level filter.
+	logger := log.NewLogfmtLogger(os.Stdout)
+	logger = level.NewFilter(logger, level.Allow(level.ParseDefault(*lvl, level.DebugValue())))
+	logger = log.With(logger, "caller", log.DefaultCaller)
+
+	// Use level helpers to log at different levels.
+	level.Error(logger).Log("err", errors.New("bad data"))
+	level.Info(logger).Log("event", "data saved")
+	level.Debug(logger).Log("next item", 17) // filtered
+
+	// Output:
+	// level=error caller=example_test.go:53 err="bad data"
+	// level=info caller=example_test.go:54 event="data saved"
 }

--- a/level/level.go
+++ b/level/level.go
@@ -144,10 +144,11 @@ func Parse(level string) (Value, error) {
 
 // ParseDefault calls Parse and returns the default Value on error.
 func ParseDefault(level string, def Value) Value {
-	if v, err := Parse(level); err == nil {
-		return v
+	v, err := Parse(level)
+	if err != nil {
+		return def
 	}
-	return def
+	return v
 }
 
 // ErrNotAllowed sets the error to return from Log when it squelches a log

--- a/level/level.go
+++ b/level/level.go
@@ -75,24 +75,24 @@ func (l *logger) Log(keyvals ...interface{}) error {
 // Option sets a parameter for the leveled logger.
 type Option func(*logger)
 
-// Allow allows to configure the log level with a Value.
+// Allow the provided log level to pass.
 func Allow(v Value) Option {
-	if v != nil {
-		switch v.String() {
-		case debugValue.name:
-			return AllowDebug()
+	switch v {
+	case debugValue:
+		return AllowDebug()
 
-		case infoValue.name:
-			return AllowInfo()
+	case infoValue:
+		return AllowInfo()
 
-		case warnValue.name:
-			return AllowWarn()
+	case warnValue:
+		return AllowWarn()
 
-		case errorValue.name:
-			return AllowError()
-		}
+	case errorValue:
+		return AllowError()
+
+	default:
+		return AllowNone()
 	}
-	return AllowNone()
 }
 
 // AllowAll is an alias for AllowDebug.
@@ -129,8 +129,9 @@ func allowed(allowed level) Option {
 	return func(l *logger) { l.allowed = allowed }
 }
 
-// Parse returns a Value from a level string. Allowed values are "debug", "info", "warn" and "error".
-// Levels are normalized via strings.TrimSpace and strings.ToLower
+// Parse a string to it's corresponding level value. Valid strings are "debug",
+// "info", "warn", and "error". Strings are normalized via strings.TrimSpace and
+// strings.ToLower.
 func Parse(level string) (Value, error) {
 	switch strings.TrimSpace(strings.ToLower(level)) {
 	case debugValue.name:
@@ -150,13 +151,12 @@ func Parse(level string) (Value, error) {
 	}
 }
 
-// ParseDefault returns a Value from a level string or the default if the level is not valid.
+// ParseDefault calls Parse and returns the default Value on error.
 func ParseDefault(level string, def Value) Value {
-	if v, err := Parse(level); err != nil {
-		return def
-	} else {
+	if v, err := Parse(level); err == nil {
 		return v
 	}
+	return def
 }
 
 // ErrNotAllowed sets the error to return from Log when it squelches a log

--- a/level/level.go
+++ b/level/level.go
@@ -7,9 +7,8 @@ import (
 	"github.com/go-kit/log"
 )
 
-var (
-	ErrInvalidLevelString = errors.New("invalid level string")
-)
+// ErrInvalidLevelString is returned whenever an invalid string is passed to Parse
+var ErrInvalidLevelString = errors.New("invalid level string")
 
 // Error returns a logger that includes a Key/ErrorValue pair.
 func Error(logger log.Logger) log.Logger {
@@ -80,16 +79,12 @@ func Allow(v Value) Option {
 	switch v {
 	case debugValue:
 		return AllowDebug()
-
 	case infoValue:
 		return AllowInfo()
-
 	case warnValue:
 		return AllowWarn()
-
 	case errorValue:
 		return AllowError()
-
 	default:
 		return AllowNone()
 	}
@@ -129,23 +124,19 @@ func allowed(allowed level) Option {
 	return func(l *logger) { l.allowed = allowed }
 }
 
-// Parse a string to it's corresponding level value. Valid strings are "debug",
+// Parse a string to its corresponding level value. Valid strings are "debug",
 // "info", "warn", and "error". Strings are normalized via strings.TrimSpace and
 // strings.ToLower.
 func Parse(level string) (Value, error) {
 	switch strings.TrimSpace(strings.ToLower(level)) {
 	case debugValue.name:
 		return debugValue, nil
-
 	case infoValue.name:
 		return infoValue, nil
-
 	case warnValue.name:
 		return warnValue, nil
-
 	case errorValue.name:
 		return errorValue, nil
-
 	default:
 		return nil, ErrInvalidLevelString
 	}

--- a/level/level.go
+++ b/level/level.go
@@ -7,7 +7,7 @@ import (
 	"github.com/go-kit/log"
 )
 
-// ErrInvalidLevelString is returned whenever an invalid string is passed to Parse
+// ErrInvalidLevelString is returned whenever an invalid string is passed to Parse.
 var ErrInvalidLevelString = errors.New("invalid level string")
 
 // Error returns a logger that includes a Key/ErrorValue pair.

--- a/level/level.go
+++ b/level/level.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	ErrInvalidLevelString = errors.New("invalid level string.")
+	ErrInvalidLevelString = errors.New("invalid level string")
 )
 
 // Error returns a logger that includes a Key/ErrorValue pair.

--- a/level/level_test.go
+++ b/level/level_test.go
@@ -12,14 +12,13 @@ import (
 )
 
 func TestVariousLevels(t *testing.T) {
-
 	testCases := []struct {
 		name    string
 		allowed level.Option
 		want    string
 	}{
 		{
-			"Allow - Debug",
+			"Allow(DebugValue)",
 			level.Allow(level.DebugValue()),
 			strings.Join([]string{
 				`{"level":"debug","this is":"debug log"}`,
@@ -29,7 +28,7 @@ func TestVariousLevels(t *testing.T) {
 			}, "\n"),
 		},
 		{
-			"Allow - Info",
+			"Allow(InfoValue)",
 			level.Allow(level.InfoValue()),
 			strings.Join([]string{
 				`{"level":"info","this is":"info log"}`,
@@ -38,7 +37,7 @@ func TestVariousLevels(t *testing.T) {
 			}, "\n"),
 		},
 		{
-			"Allow - Warn",
+			"Allow(WarnValue)",
 			level.Allow(level.WarnValue()),
 			strings.Join([]string{
 				`{"level":"warn","this is":"warn log"}`,
@@ -46,14 +45,14 @@ func TestVariousLevels(t *testing.T) {
 			}, "\n"),
 		},
 		{
-			"Allow - Error",
+			"Allow(ErrorValue)",
 			level.Allow(level.ErrorValue()),
 			strings.Join([]string{
 				`{"level":"error","this is":"error log"}`,
 			}, "\n"),
 		},
 		{
-			"Allow - nil",
+			"Allow(nil)",
 			level.Allow(nil),
 			strings.Join([]string{}, "\n"),
 		},
@@ -187,7 +186,7 @@ func TestLevelContext(t *testing.T) {
 	logger = log.With(logger, "caller", log.DefaultCaller)
 
 	level.Info(logger).Log("foo", "bar")
-	if want, have := `level=info caller=level_test.go:189 foo=bar`, strings.TrimSpace(buf.String()); want != have {
+	if want, have := `level=info caller=level_test.go:188 foo=bar`, strings.TrimSpace(buf.String()); want != have {
 		t.Errorf("\nwant '%s'\nhave '%s'", want, have)
 	}
 }
@@ -203,7 +202,7 @@ func TestContextLevel(t *testing.T) {
 	logger = level.NewFilter(logger, level.AllowAll())
 
 	level.Info(logger).Log("foo", "bar")
-	if want, have := `caller=level_test.go:205 level=info foo=bar`, strings.TrimSpace(buf.String()); want != have {
+	if want, have := `caller=level_test.go:204 level=info foo=bar`, strings.TrimSpace(buf.String()); want != have {
 		t.Errorf("\nwant '%s'\nhave '%s'", want, have)
 	}
 }

--- a/level/level_test.go
+++ b/level/level_test.go
@@ -278,56 +278,56 @@ func TestParse(t *testing.T) {
 		name    string
 		level   string
 		want    level.Value
-		wantErr bool
+		wantErr error
 	}{
 		{
 			name:    "Debug",
 			level:   "debug",
 			want:    level.DebugValue(),
-			wantErr: false,
+			wantErr: nil,
 		},
 		{
 			name:    "Info",
 			level:   "info",
 			want:    level.InfoValue(),
-			wantErr: false,
+			wantErr: nil,
 		},
 		{
 			name:    "Warn",
 			level:   "warn",
 			want:    level.WarnValue(),
-			wantErr: false,
+			wantErr: nil,
 		},
 		{
 			name:    "Error",
 			level:   "error",
 			want:    level.ErrorValue(),
-			wantErr: false,
+			wantErr: nil,
 		},
 		{
 			name:    "Case Insensitive",
 			level:   "ErRoR",
 			want:    level.ErrorValue(),
-			wantErr: false,
+			wantErr: nil,
 		},
 		{
 			name:    "Trimmed",
 			level:   " Error ",
 			want:    level.ErrorValue(),
-			wantErr: false,
+			wantErr: nil,
 		},
 		{
 			name:    "Invalid",
 			level:   "invalid",
 			want:    nil,
-			wantErr: true,
+			wantErr: level.ErrInvalidLevelString,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			got, err := level.Parse(tc.level)
-			if (err != nil) != tc.wantErr {
+			if err != tc.wantErr {
 				t.Errorf("got unexpected error %#v", err)
 			}
 

--- a/level/level_test.go
+++ b/level/level_test.go
@@ -187,7 +187,7 @@ func TestLevelContext(t *testing.T) {
 	logger = log.With(logger, "caller", log.DefaultCaller)
 
 	level.Info(logger).Log("foo", "bar")
-	if want, have := `level=info caller=level_test.go:184 foo=bar`, strings.TrimSpace(buf.String()); want != have {
+	if want, have := `level=info caller=level_test.go:189 foo=bar`, strings.TrimSpace(buf.String()); want != have {
 		t.Errorf("\nwant '%s'\nhave '%s'", want, have)
 	}
 }
@@ -203,7 +203,7 @@ func TestContextLevel(t *testing.T) {
 	logger = level.NewFilter(logger, level.AllowAll())
 
 	level.Info(logger).Log("foo", "bar")
-	if want, have := `caller=level_test.go:200 level=info foo=bar`, strings.TrimSpace(buf.String()); want != have {
+	if want, have := `caller=level_test.go:205 level=info foo=bar`, strings.TrimSpace(buf.String()); want != have {
 		t.Errorf("\nwant '%s'\nhave '%s'", want, have)
 	}
 }


### PR DESCRIPTION
This PR allows to configure the allowed log levels from a string.

Closes: #18 

Use Case:

Read the allowed log levels reading environment variable

```go
logger = level.NewFilter(logger, level.AllowByString(os.Getenv("LOG_LEVEL"), level.AllowInfo)) // <--
```