### PR TITLE
add NewTestingLogger for usage in tests

### DIFF
--- a/testing_logger.go
+++ b/testing_logger.go
@@ -1,0 +1,27 @@
+package log
+
+import (
+	"testing"
+
+	"github.com/go-logfmt/logfmt"
+)
+
+type testingLogger struct {
+	tb testing.TB
+}
+
+// NewTestingLogger returns a logger that encodes keyvals to tb.Log in
+// logfmt format. It is meant to be used in tests.
+func NewTestingLogger(tb testing.TB) Logger {
+	return testingLogger{tb}
+}
+
+func (t testingLogger) Log(keyvals ...interface{}) error {
+	t.tb.Helper()
+	buf, err := logfmt.MarshalKeyvals(keyvals...)
+	if err != nil {
+		return err
+	}
+	t.tb.Log(string(buf))
+	return nil
+}


### PR DESCRIPTION
Having access to the log can be quite useful in tests. However it is even nicer if the log is displayed only for failing tests, as well as the location where the call was made.

This PR add a `NewTestingLogger` function which supports such usecase, by calling `t.Helper` and `t.Log` with the logfmt-formatted string.

It uses `logfmt.MarshalKeyvals` directly, since I don't think that performance is so critical in tests.