### PR TITLE
Line-buffered logger

### DIFF
--- a/line_buffer.go
+++ b/line_buffer.go
@@ -1,0 +1,116 @@
+package log
+
+import (
+	"bytes"
+	"io"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// LineBufferedLogger buffers log lines to be flushed periodically. Without a line buffer, Log() will call the write
+// syscall for every log line which is expensive if logging thousands of lines per second.
+type LineBufferedLogger struct {
+	buf     *threadsafeBuffer
+	entries uint32
+	cap     uint32
+	w       io.Writer
+}
+
+// Size returns the number of entries in the buffer.
+func (l *LineBufferedLogger) Size() uint32 {
+	return atomic.LoadUint32(&l.entries)
+}
+
+// Write writes the given bytes to the line buffer, and increments the entries counter.
+// If the buffer is full (entries == cap), it will be flushed, and the entries counter reset.
+func (l *LineBufferedLogger) Write(p []byte) (n int, err error) {
+	// when we've filled the buffer, flush it
+	if l.Size() == l.cap {
+		// Flush resets the size to 0
+		if err := l.Flush(); err != nil {
+			return 0, err
+		}
+	}
+
+	atomic.AddUint32(&l.entries, 1)
+
+	return l.buf.Write(p)
+}
+
+// Flush forces the buffer to be written to the underlying writer.
+func (l *LineBufferedLogger) Flush() error {
+	if l.Size() <= 0 {
+		return nil
+	}
+
+	// reset the counter
+	atomic.StoreUint32(&l.entries, 0)
+
+	_, err := l.buf.WriteTo(l.w)
+	return err
+}
+
+// NewLineBufferedLogger creates a new LineBufferedLogger with a configured capacity and flush period.
+// Lines are flushed when the context is done, the buffer is full, or the flush period is reached.
+func NewLineBufferedLogger(w io.Writer, cap uint32, flushPeriod time.Duration) *LineBufferedLogger {
+	l := &LineBufferedLogger{
+		w:   w,
+		buf: newThreadsafeBuffer(bytes.NewBuffer([]byte{})),
+		cap: cap,
+	}
+
+	// flush periodically
+	go func() {
+		tick := time.NewTicker(flushPeriod)
+		defer tick.Stop()
+
+		for {
+			select {
+			case <-tick.C:
+				l.Flush()
+			}
+		}
+
+	}()
+
+	return l
+}
+
+// threadsafeBuffer wraps the non-threadsafe bytes.Buffer.
+type threadsafeBuffer struct {
+	sync.RWMutex
+
+	buf *bytes.Buffer
+}
+
+// Read returns the contents of the buffer.
+func (t *threadsafeBuffer) Read(p []byte) (n int, err error) {
+	t.RLock()
+	defer t.RUnlock()
+
+	return t.buf.Read(p)
+}
+
+// Write writes the given bytes to the underlying writer.
+func (t *threadsafeBuffer) Write(p []byte) (n int, err error) {
+	t.Lock()
+	defer t.Unlock()
+
+	return t.buf.Write(p)
+}
+
+// WriteTo writes the buffered lines to the given writer.
+func (t *threadsafeBuffer) WriteTo(w io.Writer) (n int64, err error) {
+	t.Lock()
+	defer t.Unlock()
+
+	return t.buf.WriteTo(w)
+}
+
+// newThreadsafeBuffer returns a new threadsafeBuffer wrapping the given bytes.Buffer.
+func newThreadsafeBuffer(buf *bytes.Buffer) *threadsafeBuffer {
+	return &threadsafeBuffer{
+		buf: buf,
+	}
+}

--- a/line_buffer.go
+++ b/line_buffer.go
@@ -67,13 +67,9 @@ func NewLineBufferedLogger(w io.Writer, cap uint32, flushPeriod time.Duration) *
 		tick := time.NewTicker(flushPeriod)
 		defer tick.Stop()
 
-		for {
-			select {
-			case <-tick.C:
-				l.Flush()
-			}
+		for range tick.C {
+			l.Flush()
 		}
-
 	}()
 
 	return l

--- a/line_buffer.go
+++ b/line_buffer.go
@@ -89,8 +89,7 @@ func WithFlushCallback(fn func(entries uint32)) LineBufferedLoggerOption {
 // WithPrellocatedBuffer preallocates a buffer to reduce GC cycles and slice resizing.
 func WithPrellocatedBuffer(size uint32) LineBufferedLoggerOption {
 	return func(l *LineBufferedLogger) {
-		l.buf = newThreadsafeBuffer(bytes.NewBuffer(make([]byte, size)))
-		l.buf.Reset()
+		l.buf = newThreadsafeBuffer(bytes.NewBuffer(make([]byte, 0, size)))
 	}
 }
 

--- a/line_buffer.go
+++ b/line_buffer.go
@@ -26,7 +26,7 @@ func (l *LineBufferedLogger) Size() uint32 {
 // If the buffer is full (entries == cap), it will be flushed, and the entries counter reset.
 func (l *LineBufferedLogger) Write(p []byte) (n int, err error) {
 	// when we've filled the buffer, flush it
-	if l.Size() == l.cap {
+	if l.Size() >= l.cap {
 		// Flush resets the size to 0
 		if err := l.Flush(); err != nil {
 			return 0, err

--- a/line_buffer_test.go
+++ b/line_buffer_test.go
@@ -1,0 +1,79 @@
+package log_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+)
+
+// BenchmarkLineBuffered creates line-buffered loggers of various capacities to see which perform best.
+func BenchmarkLineBuffered(b *testing.B) {
+	b.ReportAllocs()
+
+	for i := uint32(1); i <= 1024; i *= 2 {
+		b.Run(fmt.Sprintf("capacity:%d", i), func(b *testing.B) {
+			f := outFile(b)
+			defer os.Remove(f.Name())
+
+			bufLog := log.NewLineBufferedLogger(f, i, 10*time.Millisecond)
+			l := log.NewLogfmtLogger(log.NewSyncWriter(bufLog))
+
+			benchmarkRunner(b, l, baseMessage)
+
+			// force a final flush for outstanding lines in buffer
+			bufLog.Flush()
+
+			b.StopTimer()
+			contents, err := ioutil.ReadFile(f.Name())
+			if err != nil {
+				b.Errorf("could not read test file: %s", err)
+			}
+			lines := strings.Split(string(contents), "\n")
+			b.StartTimer()
+
+			if want, have := b.N, len(lines)-1; want != have {
+				b.Errorf("expected %d lines, have %d", want, have)
+			}
+		})
+	}
+}
+
+// BenchmarkLineUnbuffered should perform roughly equivalently to a line-buffered logger with a capacity of 1.
+func BenchmarkLineUnbuffered(b *testing.B) {
+	b.ReportAllocs()
+
+	f := outFile(b)
+	defer os.Remove(f.Name())
+
+	l := log.NewLogfmtLogger(log.NewSyncWriter(f))
+	benchmarkRunner(b, l, baseMessage)
+
+	b.StopTimer()
+	contents, err := ioutil.ReadFile(f.Name())
+	if err != nil {
+		b.Errorf("could not read test file: %s", err)
+	}
+	lines := strings.Split(string(contents), "\n")
+	b.StartTimer()
+
+	if want, have := b.N, len(lines)-1; want != have {
+		b.Errorf("expected %d lines, have %d", want, have)
+	}
+}
+
+// outFile creates a real OS file for testing.
+// We cannot use stdout/stderr since we need to read the contents after to validate, and we have to write to a file
+// to benchmark the impact of write() syscalls.
+func outFile(b *testing.B) *os.File {
+	f, err := os.OpenFile("/tmp/test", os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0666)
+	if err != nil {
+		b.Fatalf("cannot create test file: %s", err)
+	}
+
+	return f
+}

--- a/line_buffer_test.go
+++ b/line_buffer_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -46,7 +45,7 @@ func BenchmarkLineBuffered(b *testing.B) {
 			bufLog.Flush()
 			b.StopTimer()
 
-			contents, err := ioutil.ReadFile(f.Name())
+			contents, err := os.ReadFile(f.Name())
 			if err != nil {
 				b.Errorf("could not read test file: %s", err)
 			}
@@ -71,7 +70,7 @@ func BenchmarkLineUnbuffered(b *testing.B) {
 
 	b.StopTimer()
 
-	contents, err := ioutil.ReadFile(f.Name())
+	contents, err := os.ReadFile(f.Name())
 	if err != nil {
 		b.Errorf("could not read test file: %s", err)
 	}
@@ -80,6 +79,13 @@ func BenchmarkLineUnbuffered(b *testing.B) {
 	if want, have := b.N, len(lines)-1; want != have {
 		b.Errorf("expected %d lines, have %d", want, have)
 	}
+}
+
+func BenchmarkLineDiscard(b *testing.B) {
+	b.ReportAllocs()
+
+	l := log.NewLogfmtLogger(io.Discard)
+	benchmarkRunner(b, l, baseMessage)
 }
 
 func TestLineBufferedConcurrency(t *testing.T) {


### PR DESCRIPTION
The current logger implementation writes a new line to the underlying writer every time a line is logged. If this writer is  a file handle, this is mechanically unsympathetic to the Go scheduler because the goroutine and the underlying M (OS thread) are blocked while this synchronous operation occurs.

This is generally not a big deal, but when you have a program writing thousands of lines a second (we can debate the merits of that separately), this can cause a fair amount of scheduler churn. Each file write incurs both a goroutine and an OS thread context-switch, which adds up fast in high performance software.

A buffered logger protects against this by deamplifying the writes to the underlying writer (only useful if it's a file handle). We could use `bufio.NewWriter`, but then we would have incomplete lines being flushed. A line-buffered logger is the solution here.

The logger is configured to wait until a number of lines has been written, and then a flush will be triggered. I've added a couple extra features such as a preallocated buffer and a flush timeout.

In the benchmark below, I've chosen a buffer size of 256 lines, and comparing it against a normal logger writing each line to the file. Both benchmarks measure the time to write 1 million lines.

```bash
$ go test -test.bench '\QLineBuffered\E$' -test.run '^$' -benchtime=1000000x  
goos: linux
goarch: amd64
pkg: github.com/go-kit/log
cpu: Intel(R) Core(TM) i7-10510U CPU @ 1.80GHz
BenchmarkLineBuffered/capacity:256-8             1000000               399.5 ns/op            96 B/op          2 allocs/op
PASS
ok      github.com/go-kit/log   0.462s

$ go test -test.bench '\QLineUnbuffered\E$' -test.run '^$' -benchtime=1000000x
goos: linux
goarch: amd64
pkg: github.com/go-kit/log
cpu: Intel(R) Core(TM) i7-10510U CPU @ 1.80GHz
BenchmarkLineUnbuffered-8        1000000              1337 ns/op              96 B/op          2 allocs/op
PASS
```

This change improves log writing performance by roughly 70% when the writer is a file handle, and performs roughly the same if the writer is `io.Discard`:

```bash
$ go test -test.bench '\QLineDiscard\E$' -test.run '^$' -benchtime=1000000x
goos: linux
goarch: amd64
pkg: github.com/go-kit/log
cpu: Intel(R) Core(TM) i7-10510U CPU @ 1.80GHz
BenchmarkLineDiscard-8           1000000               369.4 ns/op            96 B/op          2 allocs/op
PASS
ok      github.com/go-kit/log   0.372s
```

PS: the above benchmarks have been tested with an SSD (`HP SSD EX900 Pro 1TB`).

PPS: I'm a maintainer for Grafana Loki and we implemented this in https://github.com/grafana/loki/pull/6954.