### PR TITLE
Add Windows Eventlog logger

### DIFF
--- a/eventlog/eventlog.go
+++ b/eventlog/eventlog.go
@@ -1,0 +1,141 @@
+//go:build windows
+// +build windows
+
+// Package eventlog provides a Logger that writes to Windows Event Log.
+package eventlog
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"sync"
+	"syscall"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"golang.org/x/sys/windows"
+	goeventlog "golang.org/x/sys/windows/svc/eventlog"
+)
+
+const (
+	// NeLogOemCode is a generic error log entry for OEMs to use to
+	// elog errors from OEM value added services.
+	// See: https://github.com/microsoft/win32metadata/blob/2f3c5282ce1024a712aeccd90d3aa50bf7a49e27/generation/WinSDK/RecompiledIdlHeaders/um/LMErrlog.h#L824-L845
+	neLogOemCode = uint32(3299)
+)
+
+var (
+	nullString, _ = syscall.UTF16PtrFromString("")
+)
+
+type Priority struct {
+	etype int
+}
+
+// NewEventLogLogger returns a new Logger which writes to Windows EventLog in event log format.
+// The body of the log message is the formatted output from the Logger returned
+// by newLogger.
+func NewEventLogLogger(w *goeventlog.Log, newLogger func(io.Writer) log.Logger, options ...Option) log.Logger {
+	l := &eventlogLogger{
+		w:                w,
+		newLogger:        newLogger,
+		prioritySelector: defaultPrioritySelector,
+		bufPool: sync.Pool{New: func() interface{} {
+			return &loggerBuf{}
+		}},
+	}
+
+	for _, option := range options {
+		option(l)
+	}
+
+	return l
+}
+
+type eventlogLogger struct {
+	w                *goeventlog.Log
+	newLogger        func(io.Writer) log.Logger
+	prioritySelector PrioritySelector
+	bufPool          sync.Pool
+}
+
+func (l *eventlogLogger) Log(keyvals ...interface{}) error {
+	priority := l.prioritySelector(keyvals...)
+
+	lb := l.getLoggerBuf()
+	defer l.putLoggerBuf(lb)
+	if err := lb.logger.Log(keyvals...); err != nil {
+		return err
+	}
+
+	// golang.org/x/sys/windows/svc/eventlog does not provide func which allows to send more than one string.
+	// See: https://github.com/golang/go/issues/59780
+
+	msg, err := syscall.UTF16PtrFromString(lb.buf.String())
+	if err != nil {
+		return fmt.Errorf("error convert string to UTF-16: %v", err)
+	}
+
+	ss := []*uint16{msg, nullString, nullString, nullString, nullString, nullString, nullString, nullString, nullString}
+	return windows.ReportEvent(l.w.Handle, uint16(priority.etype), 0, neLogOemCode, 0, 9, 0, &ss[0], nil)
+}
+
+type loggerBuf struct {
+	buf    *bytes.Buffer
+	logger log.Logger
+}
+
+func (l *eventlogLogger) getLoggerBuf() *loggerBuf {
+	lb := l.bufPool.Get().(*loggerBuf)
+	if lb.buf == nil {
+		lb.buf = &bytes.Buffer{}
+		lb.logger = l.newLogger(lb.buf)
+	} else {
+		lb.buf.Reset()
+	}
+	return lb
+}
+
+func (l *eventlogLogger) putLoggerBuf(lb *loggerBuf) {
+	l.bufPool.Put(lb)
+}
+
+// Option sets a parameter for eventlog loggers.
+type Option func(*eventlogLogger)
+
+// PrioritySelector inspects the list of keyvals and selects an eventlog priority.
+type PrioritySelector func(keyvals ...interface{}) Priority
+
+// PrioritySelectorOption sets priority selector function to choose eventlog
+// priority.
+func PrioritySelectorOption(selector PrioritySelector) Option {
+	return func(l *eventlogLogger) { l.prioritySelector = selector }
+}
+
+// defaultPrioritySelector convert a kit/log level into a Windows Eventlog level
+func defaultPrioritySelector(keyvals ...interface{}) Priority {
+	l := len(keyvals)
+
+	eType := windows.EVENTLOG_SUCCESS
+
+	for i := 0; i < l; i += 2 {
+		if keyvals[i] == level.Key() {
+			var val interface{}
+			if i+1 < l {
+				val = keyvals[i+1]
+			}
+			if v, ok := val.(level.Value); ok {
+				switch v {
+				case level.ErrorValue():
+					eType = windows.EVENTLOG_ERROR_TYPE
+				case level.WarnValue():
+					eType = windows.EVENTLOG_WARNING_TYPE
+				case level.InfoValue():
+					eType = windows.EVENTLOG_INFORMATION_TYPE
+				}
+			}
+		}
+	}
+
+	return Priority{etype: eType}
+}

--- a/eventlog/eventlog_test.go
+++ b/eventlog/eventlog_test.go
@@ -1,0 +1,44 @@
+//go:build windows
+// +build windows
+
+// Package eventlog provides a Logger that writes to Windows Event Log.
+package eventlog
+
+import (
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	goeventlog "golang.org/x/sys/windows/svc/eventlog"
+)
+
+func TestLog(t *testing.T) {
+	const name = "go-kit-log"
+
+	w, err := goeventlog.Open(name)
+	if err != nil {
+		t.Fatalf("Open failed: %s", err)
+	}
+	defer w.Close()
+
+	logger := NewEventLogLogger(w, log.NewLogfmtLogger)
+
+	err = level.Debug(logger).Log("msg", "debug")
+	if err != nil {
+		t.Fatalf("debug failed: %s", err)
+	}
+	err = level.Info(logger).Log("msg", "info")
+	if err != nil {
+		t.Fatalf("Info failed: %s", err)
+	}
+	err = level.Warn(logger).Log("msg", "warn")
+	if err != nil {
+		t.Fatalf("Warning failed: %s", err)
+	}
+	err = level.Error(logger).Log("msg", "err")
+	if err != nil {
+		t.Fatalf("Error failed: %s", err)
+	}
+
+	err = level.Error(logger).Log("msg", "err")
+}

--- a/eventlog/example_test.go
+++ b/eventlog/example_test.go
@@ -1,0 +1,42 @@
+//go:build windows
+// +build windows
+
+package eventlog_test
+
+import (
+	"fmt"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/eventlog"
+	"github.com/go-kit/log/level"
+	goeventlog "golang.org/x/sys/windows/svc/eventlog"
+)
+
+func ExampleNewEventLogLogger_defaultPrioritySelector() {
+	// Normal eventlog writer
+	w, err := goeventlog.Open("go-kit-log")
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	logger := eventlog.NewEventLogLogger(w, log.NewLogfmtLogger)
+
+	type Task struct {
+		ID int
+	}
+
+	RunTask := func(task Task, logger log.Logger) {
+		logger.Log("taskID", task.ID, "event", "starting task")
+
+		logger.Log("taskID", task.ID, level.Key(), level.DebugValue(), "msg", "debug because of explicit level")
+		logger.Log("taskID", task.ID, level.Key(), level.WarnValue(), "msg", "warn because of explicit level")
+		logger.Log("taskID", task.ID, level.Key(), level.ErrorValue(), "msg", "error because of explicit level")
+
+		logger.Log("taskID", task.ID, "event", "task complete")
+	}
+
+	RunTask(Task{ID: 1}, logger)
+
+	// Output:
+}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/go-kit/log
 
 go 1.17
 
-require github.com/go-logfmt/logfmt v0.5.1
+require (
+	github.com/go-logfmt/logfmt v0.5.1
+	golang.org/x/sys v0.7.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/go-logfmt/logfmt v0.5.1 h1:otpy5pqBCBZ1ng9RQ0dPu4PN7ba75Y/aA+UpowDyNVA=
 github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
+golang.org/x/sys v0.7.0 h1:3jlCCIQZPdOYu1h8BkNvLz8Kgwtae2cagcG/VamtZRU=
+golang.org/x/sys v0.7.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
Based on the syslog package.

Useful for golang applications running on Windows.

go does not provide a way to read or fetch Windows Event Logs. The tests are limited to sending only, but can't check if the log entry is present.

Tested on a real Windows machine.